### PR TITLE
str_replace()- escape possible issues with delims

### DIFF
--- a/lib/ereg.php
+++ b/lib/ereg.php
@@ -3,32 +3,33 @@ namespace {
     if (!function_exists('ereg')) {
         function ereg($pattern, $subject, &$matches = array())
         {
-            return preg_match('/'.$pattern.'/', $subject, $matches);
+            return preg_match('/'.str_replace("/", "\/", $pattern).'/', $subject, $matches);
         }
 
         function eregi($pattern, $subject, &$matches = array())
         {
-            return preg_match('/'.$pattern.'/i', $subject, $matches);
+            return preg_match('/'.str_replace("/", "\/", $pattern).'/i', $subject, $matches);
         }
 
         function ereg_replace($pattern, $replacement, $string)
         {
-            return preg_replace('/'.$pattern.'/', $replacement, $string);
+            return preg_replace('/'.str_replace("/", "\/", $pattern).'/', $replacement, $string);
         }
 
         function eregi_replace($pattern, $replacement, $string)
         {
-            return preg_replace('/'.$pattern.'/i', $replacement, $string);
+            return preg_replace('/'.str_replace("/", "\/", $pattern).'/i', $replacement, $string);
         }
 
         function split($pattern, $subject, $limit = -1)
         {
-            return preg_split('/'.$pattern.'/', $subject, $limit);
+            return preg_split('/'.str_replace("/", "\/", $pattern).'/', $subject, $limit);
         }
 
         function spliti($pattern, $subject, $limit = -1)
         {
-            return preg_split('/'.$pattern.'/i', $subject, $limit);
+            return preg_split('/'.str_replace("/", "\/", $pattern).'/i', $subject, $limit);
         }
     }
 }
+?>


### PR DESCRIPTION
Added trivial inline str_replace() to escape possibly passed delimiters.  This still isn't really a replacement for ereg() functions, but makes trivial use, well, trivial.

(Sorry it took me so long to see your note- my email address tied to github was partially inaccessible while migrating to an external service, and let's just say quite a bit was flagged incorrectly.)