### PR TITLE
Remove ± as boundary, it's not single byte

### DIFF
--- a/lib/ereg.php
+++ b/lib/ereg.php
@@ -52,7 +52,7 @@ namespace {
          */
         function _ereg_determine_boundary($pattern) 
         {
-            foreach (array('/', '@', '#', '%', '±') as $boundary) {
+            foreach (array('/', '@', '#', '%') as $boundary) {
                 if (false === strpos($pattern, $boundary)) { 
                     return $boundary;
                 }


### PR DESCRIPTION
The boundary is supposed to be ASCII character, yet `±` committed in this code is UTF-8 encoded and therefore 2 bytes:

```
➔ echo -n ±|wc -c
2
```

```
$ php -r 'preg_match("±pattern±", ".");'
PHP Warning:  preg_match(): Delimiter must not be alphanumeric or backslash in Command line code on line 1
```